### PR TITLE
修复在Overleaf系统上使用该模板的些许问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 对于使用 [Overleaf](https://www.overleaf.com/) 或其他尚未安装 *华文中宋 (STzhongsong)* 字体的系统，请在 [`main.tex`](main.tex) 中导入文档类 [`whut-bachelor`](whut-bachelor.cls) 时传入参数 `noextrafonts`
 (即 `\documentclass[noextrafonts]{whut-bachelor}`)。
-**注意**：此时封面标题等部分字体将不再满足《武汉理工大学本科生毕业设计（论文）撰写规范》要求，请于之后手动修改。
+**注意**：此时封面标题等部分使用“华文中宋”字体的内容将使用repo中[STZhongsong.ttf](./blob/master/STZhongsong.ttf)文件来满足字体要求。
 
 ### 目录结构
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 参照 [`main.tex`](main.tex) 以及 [`body/`](body/) 文件夹中文件修改即可。
 
 对于使用 [Overleaf](https://www.overleaf.com/) 或其他尚未安装 *华文中宋 (STzhongsong)* 字体的系统，请在 [`main.tex`](main.tex) 中导入文档类 [`whut-bachelor`](whut-bachelor.cls) 时传入参数 `noextrafonts`
-(即 `\documentclass[noextrafonts]{whut-bachelor}`)。
-**注意**：此时封面标题等部分使用“华文中宋”字体的内容将使用repo中[STZhongsong.ttf](./blob/master/STZhongsong.ttf)文件来满足字体要求。
+(即 `\documentclass[noextrafonts]{whut-bachelor}`)。  
+**注意**：此时封面标题等部分使用“华文中宋”字体的内容将使用repo中[STZhongsong.ttf](./STZhongsong.ttf)文件来满足字体要求。
 
 ### 目录结构
 

--- a/whut-bachelor.cls
+++ b/whut-bachelor.cls
@@ -44,7 +44,7 @@
 %\RequirePackage{ctex}
 
 \ifwhut@options@noextrafonts
-	\providecommand{\zhongsong}{}
+	\providecommand{\zhongsong}{\CJKfontspec{STZhongsong.ttf}} % 外部华文中宋字体
 \else
 	\providecommand{\zhongsong}{\CJKfontspec{STZhongsong}}	%华文中宋
 \fi

--- a/whut-bachelor.cls
+++ b/whut-bachelor.cls
@@ -113,6 +113,9 @@
 	allcolors=blue,
 	pdfsubject={WHUT Bachelor Thesis},
 	pdfcreator={whut-bachelor class [github.com/Markhng/WHUT-Bachelor]},
+	colorlinks=true,
+    linkcolor=black, % 不加入此项时Overleaf导出PDF会将链接用红框圈起
+    citecolor=black, % 不加入此项时Overleaf导出PDF会将引用用绿框圈起
 	%	linkcolor=MidnightBlue,
 	%	citecolor=Olive,
 	%	pdfborder=001


### PR DESCRIPTION
修复问题如下：

- 在Overleaf及其他不包含“华文中宋”字体的系统下编译生成的文件中字体需自己调整的问题
- 在Overleaf中导出PDF时链接(e.g.目录链接)及引用会被彩色框圈起的问题
- 修改了README.md文件中“华文中宋”字体相关的部分内容