### PR TITLE
Use 'KaiTi' for italic font on Linux with SimSum font installed

### DIFF
--- a/whut-bachelor.cls
+++ b/whut-bachelor.cls
@@ -61,7 +61,7 @@
 
 \ifwhut@options@heitipatch
 	\IfFontExistsTF{SimSun}{
-		\setCJKmainfont{SimSun}[BoldFont={SimHei}, ItalicFont={SimKai}]
+		\setCJKmainfont{SimSun}[BoldFont={SimHei}, ItalicFont={KaiTi}]
 	}{
 		\setCJKmainfont{FandolSong}[BoldFont={FandolHei}, ItalicFont={FandolKai}]
 	}


### PR DESCRIPTION
修复#8。
但是没有经过Windows环境下的测试，不清楚是否适用于Windows。